### PR TITLE
Add a generic field setter

### DIFF
--- a/utilitiesApp/Db/Makefile
+++ b/utilitiesApp/Db/Makefile
@@ -13,6 +13,7 @@ include $(TOP)/configure/CONFIG
 #DB += xxx.db
 DB += unit_setter.template
 DB += error_setter.template
+DB += field_setter.template
 DB += calibration_range.db
 
 #----------------------------------------------------

--- a/utilitiesApp/Db/field_setter.template
+++ b/utilitiesApp/Db/field_setter.template
@@ -1,0 +1,10 @@
+
+record(stringout, "$(P)$(TO):RAW")
+{
+    field(DESC, "Push a field from one pv to another")
+    field(DOL, "$(P)$(FROM).$(FIELD=VAL) CP")
+	field(OMSL, "closed_loop")
+    field(OUT,  "$(P)$(TO).$(FIELD=VAL) $(PROCESS_FLAGS=PP)")
+}
+
+


### PR DESCRIPTION
### Description of work

Adds a generic 'field setter', which copies the value of a PV's field to a different PV.

### To test
https://github.com/ISISComputingGroup/IBEX/issues/4695

### Acceptance criteria
- [ ] New file builds in the ibex build system
- [ ] Added record copies values between records
- [ ] New functionality is appropriately documented (see https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Utilities#field-setter)