### PR TITLE
Add a simple stability check DB.

### DIFF
--- a/iocBoot/iocutilitiesTest/st.cmd
+++ b/iocBoot/iocutilitiesTest/st.cmd
@@ -32,6 +32,11 @@ iocshCmdList("dbgrep $(MYPVPREFIX)A\$(S)*", "", "S", "X;Y;Z", ";")
 # variables for use in the script and then reset back to their pre-script values
 iocshCmdLoop("< st\$(I).cmd", "Q=Hello\$(I)", "I", 1, 2)
 
+
+epicsEnvSet("NAME", "UTILITIESTEST")
+dbLoadRecords("$(TOP)/db/simple_val.db", "P=$(MYPVPREFIX)$(NAME):")
+dbLoadRecords("$(UTILITIES)/db/check_stability.db", "P=$(MYPVPREFIX)$(NAME):,INP_VAL=$(MYPVPREFIX)$(NAME):VAL,SP=$(MYPVPREFIX)$(NAME):VAL:SP,NSAMP=$(NSAMP=5),TOLERANCE=$(TOLERANCE=0.1)")
+
 # confirm Q is unset on return
 epicsEnvShow Q
 

--- a/utilitiesApp/Db/Makefile
+++ b/utilitiesApp/Db/Makefile
@@ -15,6 +15,8 @@ DB += unit_setter.template
 DB += error_setter.template
 DB += field_setter.template
 DB += calibration_range.db
+DB += check_stability.db
+DB += simple_val.db
 
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add

--- a/utilitiesApp/Db/check_stability.db
+++ b/utilitiesApp/Db/check_stability.db
@@ -1,0 +1,80 @@
+#
+# Checks that a given PV has been "stable" for a specified amount of time
+#
+# Macros: 
+#   $(P) - a unique PV prefix for this DB. This prefix must be different each time you load this db into one IOC.
+#   $(INP_VAL) - A PV containing the input value (e.g. readback from the device)
+#   $(SP) - A PV containing the setpoint value (e.g. an SP:RBV from the device)
+#   $(NSAMP) - number of samples needed before value can be declared stable
+#   $(TOLERANCE) - The tolerance to apply between the setpoint and the readback
+#
+# Public API:
+#   $(P)STAB:SCANNOW - Process this PV when a new sample should be taken (e.g. FLNK to this from $(INP_VAL) )
+#   $(P)STAB:HAS_RECENT_ALARM - 1 if the input PV has been in alarm for any of the last $(NSAMP) samples, 0 otherwise
+#   $(P)STAB:IS_STABLE - 1 if the input PV has not been in alarm and continuously within tolerance of $(SP) for the last $(NSAMP) samples
+#
+
+record(bo, "$(P)STAB:SCANNOW") {
+  field(FLNK, "$(P)STAB:_SEVR_BUFF")
+}
+
+# Circular buffer of values severities
+record(compress, "$(P)STAB:_SEVR_BUFF") {
+  field(INP, "$(INP_VAL).SEVR")
+  field(ALG, "Circular Buffer")
+  field(NSAM, "$(NSAMP)")
+  field(FLNK, "$(P)STAB:_SEVR_COMP")
+}
+
+# Selects largest error status from circular buffer above.
+# If >=3, there has been a comms error in the last $(NSAMP) samples.
+record(compress, "$(P)STAB:_SEVR_COMP") {
+  field(INP, "$(P)STAB:_SEVR_BUFF")
+  field(ALG, "N to 1 High Value")
+  field(NSAM, "1")
+  field(N, "$(NSAMP)")
+  field(FLNK, "$(P)STAB:HAS_RECENT_ALARM")
+}
+
+# Whether any of the last $(NSAMP) samples have had an alarm >= 3 (INVALID)
+record(calc, "$(P)STAB:HAS_RECENT_ALARM") {
+  field(INPA, "$(P)STAB:_SEVR_COMP")
+  field(CALC, "A>=3")
+  field(ASG, "READONLY")
+  field(FLNK, "$(P)STAB:_VAL_BUFF")
+}
+
+# Circular buffer of values sampled from $(INP_VAL)
+record(compress, "$(P)STAB:_VAL_BUFF") {
+  field(INP, "$(INP_VAL)")
+  field(ALG, "Circular Buffer")
+  field(NSAM, "$(NSAMP)")
+  field(FLNK, "$(P)STAB:_VAL_HIGHEST")
+}
+
+# Highest sampled value (within the last $(NSAMP) samples)
+record(compress, "$(P)STAB:_VAL_HIGHEST") {
+  field(INP, "$(P)STAB:_VAL_BUFF")
+  field(ALG, "N to 1 High Value")
+  field(NSAM, "1")
+  field(N, "$(NSAMP)")
+  field(FLNK, "$(P)STAB:_VAL_LOWEST")
+}
+
+# Lowest sampled value (within the last $(NSAMP) samples)
+record(compress, "$(P)STAB:_VAL_LOWEST") {
+  field(INP, "$(P)STAB:_VAL_BUFF")
+  field(ALG, "N to 1 Low Value")
+  field(NSAM, "1")
+  field(N, "$(NSAMP)")
+  field(FLNK, "$(P)STAB:IS_STABLE")
+}
+
+record(calc, "$(P)STAB:IS_STABLE") {
+  field(INPA, "$(P)STAB:HAS_RECENT_ALARM")
+  field(INPB, "$(P)STAB:_VAL_HIGHEST")
+  field(INPC, "$(P)STAB:_VAL_LOWEST")
+  field(INPD, "$(SP)")
+  field(E, "$(TOLERANCE)")
+  field(CALC, "(!A) && (ABS(B-D)<=E) && (ABS(C-D)<=E)")
+}

--- a/utilitiesApp/Db/simple_val.db
+++ b/utilitiesApp/Db/simple_val.db
@@ -1,0 +1,15 @@
+# DB used by IOC tests to test check_stability.db
+
+record(ao, "$(P)VAL") {
+  field(VAL, "0")
+  field(PINI, "YES")
+  field(SIMM, "YES")
+  
+  field(FLNK, "$(P)STAB:SCANNOW")
+}
+
+record(ao, "$(P)VAL:SP") {
+  field(VAL, "0")
+  field(PINI, "YES")
+  field(SIMM, "YES")
+}


### PR DESCRIPTION
This adds a generic stability-checking DB.

Documentation: https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-Utilities#check-stability

Tests: https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/279

Ticket: https://github.com/ISISComputingGroup/IBEX/issues/5043