### PR TITLE
Ticket 5513: Updated to the standard epics way of running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,4 @@ $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir)
 utilitiesTestApp_DEPEND_DIRS += utilitiesApp
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 
-TEST_RUNNER = $(TOP)/utilitiesApp/src/O.$(EPICS_HOST_ARCH)/runner
-
 include $(TOP)/configure/RULES_TOP
-
-.PHONY: test
-test:
-ifneq ($(wildcard $(TEST_RUNNER)*),)
-	$(TEST_RUNNER) --gtest_output=xml:$(TOP)/test-reports/TEST-Utilities.xml
-endif

--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -54,12 +54,10 @@ BIN_INSTALLS_WIN32 += $(wildcard $(PCRE)/bin/$(EPICS_HOST_ARCH)/*.dll)
 ifeq ($(findstring 10.0,$(VCVERSION)),)
 SRC_DIRS += $(TOP)/utilitiesApp/tests
 
-TESTPROD_HOST += runner
-USR_CPPFLAGS += -I$(GTEST)/googletest/include 
-runner_SRCS += run_all_tests.cc
+GTESTPROD_HOST += runner
 runner_SRCS += calibration_range_tests.cc
 runner_SRCS += find_calibration_range_utils.cpp
-runner_LIBS += gtest
+GTESTS += runner 
 endif
 
 #===========================
@@ -67,4 +65,4 @@ endif
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
-
+include $(GTEST)/cfg/compat.RULES_BUILD

--- a/utilitiesApp/tests/run_all_tests.cc
+++ b/utilitiesApp/tests/run_all_tests.cc
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5513

To test:

* Run `make runtests` in this submodule and confirm tests run