### PR TITLE
Ticket6754: beckhoff axes checking

### DIFF
--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -22,7 +22,7 @@ DBD += utilities.dbd
 INC += utilities.h win32_dirent.h
 
 # specify all source files to be compiled and added to the library
-utilities_SRCS += iocname.cpp trimString.cpp ioccalc.cpp iocdcalc.cpp compress.cpp mkdir.cpp iocstringtest.cpp 
+utilities_SRCS += iocname.cpp trimString.cpp ioccalc.cpp iocdcalc.cpp compress.cpp mkdir.cpp iocstringtest.cpp iocshHelpers.cpp
 utilities_SRCS += FileList.cpp json.cpp dbLoadRecordsFuncs.cpp iocshCmdFuncs.cpp freeIPPort.cpp msgBox.cpp
 utilities_SRCS_WIN32 += win32_dirent.c getProcessUptime.cpp
 

--- a/utilitiesApp/src/iocshHelpers.cpp
+++ b/utilitiesApp/src/iocshHelpers.cpp
@@ -1,0 +1,73 @@
+#include "dbAccessDefs.h"
+#include "dbStaticLib.h"
+#include "epicsString.h"
+#include "envDefs.h"
+#include "iocsh.h"
+#include "epicsExport.h"
+
+
+long countdbgrep(const char* resultvar, const char *pmask) {
+    int count = 0;
+    DBENTRY dbentry;
+    DBENTRY *pdbentry = &dbentry;
+    long status;
+    if (!pmask || !*pmask) {
+        printf("Usage: dbgrep \"pattern\"\n");
+        return 1;
+    }
+    if (!pdbbase) {
+        printf("No database loaded\n");
+        return 0;
+    }
+    dbInitEntry(pdbbase, pdbentry);
+    status = dbFirstRecordType(pdbentry);
+    while (!status) {
+        status = dbFirstRecord(pdbentry);
+        while (!status) {
+            char *pname = dbGetRecordName(pdbentry);
+            if (epicsStrGlobMatch(pname, pmask))
+                count++;
+            status = dbNextRecord(pdbentry);
+        }
+        status = dbNextRecordType(pdbentry);
+    }
+
+    dbFinishEntry(pdbentry);
+    char result_str[32];
+    sprintf(result_str, "%i", count);
+    epicsEnvSet(resultvar, result_str);
+    return 0;
+}
+
+
+extern "C" {
+
+// EPICS iocsh shell commands 
+
+static const iocshArg countdbgrepInitArg0 = { "resultvar", iocshArgString }; ///< The name of the macro to put the result of the calculation into.
+static const iocshArg countdbgrepInitArg1 = { "pmask", iocshArgString }; ///< The left hand side argument.
+
+static const iocshArg * const countdbgrepInitArgs[] = { &countdbgrepInitArg0, &countdbgrepInitArg1};
+
+static const iocshFuncDef countdbgrepInitFuncDef = {"countdbgrep", sizeof(countdbgrepInitArgs) / sizeof(iocshArg*), countdbgrepInitArgs};
+
+static void countdbgrepInitCallFunc(const iocshArgBuf *args)
+{
+    countdbgrep(args[0].sval, args[1].sval);
+}
+
+static void ioccountdbgrepRegister(void)
+{
+    iocshRegister(&countdbgrepInitFuncDef, countdbgrepInitCallFunc);
+}
+
+epicsExportRegistrar(ioccountdbgrepRegister); // need to be declared via registrar() in utilities.dbd too
+
+// asub callable functions - need to be in utilities.dbd as function() 
+
+//epicsRegisterFunction(setIOCName); 
+//epicsRegisterFunction(getIOCName); 
+//epicsRegisterFunction(getIOCGroup); 
+
+}
+

--- a/utilitiesApp/src/iocshHelpers.cpp
+++ b/utilitiesApp/src/iocshHelpers.cpp
@@ -5,7 +5,14 @@
 #include "iocsh.h"
 #include "epicsExport.h"
 
-
+/// Search for PVs that match the specified pattern (as dbgrep) and put the number of found PVs in the specified macro.
+///
+/// @code
+///     countdbgrep("NUM_AXES", "*AXIS*")
+/// @endcode 
+///
+/// @param[in] resultvar The name of the macro to output the result into
+/// @param[in] pmask The pattern to search for
 long countdbgrep(const char* resultvar, const char *pmask) {
     int count = 0;
     DBENTRY dbentry;
@@ -62,12 +69,6 @@ static void ioccountdbgrepRegister(void)
 }
 
 epicsExportRegistrar(ioccountdbgrepRegister); // need to be declared via registrar() in utilities.dbd too
-
-// asub callable functions - need to be in utilities.dbd as function() 
-
-//epicsRegisterFunction(setIOCName); 
-//epicsRegisterFunction(getIOCName); 
-//epicsRegisterFunction(getIOCGroup); 
 
 }
 

--- a/utilitiesApp/src/utilities.dbd
+++ b/utilitiesApp/src/utilities.dbd
@@ -1,6 +1,7 @@
 registrar(ioccalcRegister)
 registrar(iocdcalcRegister)
 registrar(iocstringtestRegister)
+registrar(countdbgrepRegister)
 registrar(iocnameRegister)
 registrar(mkdirRegister)
 registrar(dbLoadRecordsFuncsRegister)

--- a/utilitiesApp/src/utilities.dbd
+++ b/utilitiesApp/src/utilities.dbd
@@ -1,7 +1,7 @@
 registrar(ioccalcRegister)
 registrar(iocdcalcRegister)
 registrar(iocstringtestRegister)
-registrar(countdbgrepRegister)
+registrar(ioccountdbgrepRegister)
 registrar(iocnameRegister)
 registrar(mkdirRegister)
 registrar(dbLoadRecordsFuncsRegister)


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/6754

This function checks how many PVs matching a pattern are loaded into an IOC. It is used in the Beckhoff IOC to work out how many axes we have.