### PR TITLE
Ticket 6433: Use NPP as default

### DIFF
--- a/utilitiesApp/Db/unit_setter.template
+++ b/utilitiesApp/Db/unit_setter.template
@@ -4,7 +4,7 @@ record(stringout, "$(P)$(TO):UNITS_SET")
     field(DESC, "Push units from one pv to another")
     field(DOL, "$(P)$(FROM) CP")
 	field(OMSL, "closed_loop")
-    field(OUT,  "$(P)$(TO).EGU $(PROCESS_FLAGS=PP)")
+    field(OUT,  "$(P)$(TO).EGU $(PROCESS_FLAGS=NPP)")
 }
 
 


### PR DESCRIPTION
One character change to make the default NPP.

### Ticket:

https://github.com/ISISComputingGroup/IBEX/issues/6433

### Acceptance Criteria:

When this template is used, the process flags are applied as appropriate, e.g. this:
``` 
file $(UTILITIES)/db/unit_setter.template { 
  pattern 
    {P,    FROM, TO,}
	
	{"\$(P)", "A", "1"} 
}

file $(UTILITIES)/db/unit_setter.template { 
  pattern 
    {P,    FROM, TO, PROCESS_FLAGS}
    
    {"\$(P)", "B", "2", "PP"} 
    {"\$(P)", "C", "3", "NPP"} 
    {"\$(P)", "D", "4", ""} 
}
```
will result in this:
```
record(stringout, "$(P)1:UNITS_SET")
{
    field(DESC, "Push units from one pv to another")
    field(DOL, "$(P)A CP")
	field(OMSL, "closed_loop")
    field(OUT,  "$(P)1.EGU NPP")
}



record(stringout, "$(P)2:UNITS_SET")
{
    field(DESC, "Push units from one pv to another")
    field(DOL, "$(P)B CP")
	field(OMSL, "closed_loop")
    field(OUT,  "$(P)2.EGU PP")
}



record(stringout, "$(P)3:UNITS_SET")
{
    field(DESC, "Push units from one pv to another")
    field(DOL, "$(P)C CP")
	field(OMSL, "closed_loop")
    field(OUT,  "$(P)3.EGU NPP")
}



record(stringout, "$(P)4:UNITS_SET")
{
    field(DESC, "Push units from one pv to another")
    field(DOL, "$(P)D CP")
	field(OMSL, "closed_loop")
    field(OUT,  "$(P)4.EGU ")
}


```