### PR TITLE
Allow dbloadrecordsloop to handle nesed macros

### DIFF
--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -59,8 +59,9 @@ ifeq ($(findstring 10.0,$(VCVERSION)),)
 SRC_DIRS += $(TOP)/utilitiesApp/tests
 
 GTESTPROD_HOST += runner
-runner_SRCS += calibration_range_tests.cc find_calibration_range_tests.cc
-runner_SRCS += find_calibration_range_utils.cpp find_calibration_range_impl.cpp
+runner_SRCS += calibration_range_tests.cc find_calibration_range_tests.cc dbLoadRecordsFuncs_tests.cc
+runner_SRCS += find_calibration_range_utils.cpp find_calibration_range_impl.cpp dbLoadRecordsFuncs.cpp
+runner_LIBS += zlib pcrecpp pcre libjson
 runner_LIBS += $(EPICS_BASE_IOC_LIBS)
 GTESTS += runner 
 endif

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -70,15 +70,17 @@ static void loadMacEnviron(MAC_HANDLE* pmh)
 /// look for e.g. \$() and replace with $() so we can substitute later with macEnvExpand()
 static void subMacros(std::string& new_macros, const char* macros)
 {
+    const std::regex bracketPattern = std::regex(R"(\\\$\(([0-9a-zA-Z_$(){}]+)\))")
+    const std::regex bracePattern = std::regex(R"(\\\$\{([0-9a-zA-Z_$(){}]+)\})")
     new_macros = macros;
     std::smatch bracketSearch, braceSearch;
     // Check that we have done a search, and that the result of both is empty before finishing.
     while((!bracketSearch.empty())||(!braceSearch.empty())||(!bracketSearch.ready())){
-        std::regex_search(new_macros, bracketSearch, std::regex(R"(\\\$\(([0-9a-zA-Z_\$\(\){}]+)\))"));
-        new_macros = std::regex_replace(new_macros, std::regex(R"(\\\$\(([0-9a-zA-Z_\$\(\){}]+)\))"), "$($1)");
+        std::regex_search(new_macros, bracketSearch, bracketPattern);
+        new_macros = std::regex_replace(new_macros, bracketPattern, "$($1)");
         // Have to look twice to guarantee that brackets/curly braces are properly matched.
-        std::regex_search(new_macros, braceSearch, std::regex(R"(\\\$\{([0-9a-zA-Z_\$\(\){}]+)\})"));
-        new_macros = std::regex_replace(new_macros, std::regex(R"(\\\$\{([0-9a-zA-Z_\$\(\){}]+)\})"), "$($1)");
+        std::regex_search(new_macros, braceSearch, bracePattern);
+        new_macros = std::regex_replace(new_macros, bracePattern, "${$1}");
     }
 }
 

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -68,10 +68,10 @@ static void loadMacEnviron(MAC_HANDLE* pmh)
 }
 
 /// look for e.g. \$() and replace with $() so we can substitute later with macEnvExpand()
-static void subMacros(std::string& new_macros, const char* macros)
+void subMacros(std::string& new_macros, const char* macros)
 {
-    const std::regex bracketPattern = std::regex(R"(\\\$\(([0-9a-zA-Z_$(){}]+)\))")
-    const std::regex bracePattern = std::regex(R"(\\\$\{([0-9a-zA-Z_$(){}]+)\})")
+    const std::regex bracketPattern = std::regex(R"(\\\$\(([0-9a-zA-Z_$(){}]+)\))");
+    const std::regex bracePattern = std::regex(R"(\\\$\{([0-9a-zA-Z_$(){}]+)\})");
     new_macros = macros;
     std::smatch bracketSearch, braceSearch;
     // Check that we have done a search, and that the result of both is empty before finishing.

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -44,12 +44,12 @@
 #include "pcrecpp.h"
 
 #include <string.h>
+#include <regex>
 #include <registryFunction.h>
 
 #include <epicsExport.h>
 
 #include "utilities.h"
-#include <regex>
 
 /// load current environment into mac handle 
 static void loadMacEnviron(MAC_HANDLE* pmh)

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -71,21 +71,14 @@ static void loadMacEnviron(MAC_HANDLE* pmh)
 static void subMacros(std::string& new_macros, const char* macros, const char* loopVar)
 {
     new_macros = macros;
-    std::smatch m;
-    int i =0;
-    while((!m.empty())||(!m.ready())){
-        i++;
-        std::regex_search(new_macros, m, std::regex(R"(\\\$\(([0-9a-zA-Z_\$\(\){}]+)\))"));
-        std::cout << "iteration " << i << " macros: " << new_macros << " size: " << m.size() << " m0" << m[0] <<"\n";
+    std::smatch bracketSearch, braceSearch;
+    // Check that we have done a search, and that the result of both is empty before finishing.
+    while((!bracketSearch.empty())||(!braceSearch.empty())||(!bracketSearch.ready())){
+        std::regex_search(new_macros, bracketSearch, std::regex(R"(\\\$\(([0-9a-zA-Z_\$\(\){}]+)\))"));
         new_macros = std::regex_replace(new_macros, std::regex(R"(\\\$\(([0-9a-zA-Z_\$\(\){}]+)\))"), "$($1)");
-    }
-    i=0;
-    // Have to look twice to guarantee that brackets/curly braces are properly matched.
-    while((!m.empty())||(!m.ready())){
-        i++;
-        std::regex_search(new_macros, m, std::regex(R"(\\\${([0-9a-zA-Z_\$\(\){}]+)})"));
-        std::cout << "iteration " << i << " macros: " << new_macros << " size: " << m.size() << " m0" << m[0] <<"\n";
-        new_macros = std::regex_replace(new_macros, std::regex(R"(\\\${([0-9a-zA-Z_\$\(\){}]+)})"), "$($1)");
+        // Have to look twice to guarantee that brackets/curly braces are properly matched.
+        std::regex_search(new_macros, braceSearch, std::regex(R"(\\\$\{([0-9a-zA-Z_\$\(\){}]+)\})"));
+        new_macros = std::regex_replace(new_macros, std::regex(R"(\\\$\{([0-9a-zA-Z_\$\(\){}]+)\})"), "$($1)");
     }
 }
 

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -68,7 +68,7 @@ static void loadMacEnviron(MAC_HANDLE* pmh)
 }
 
 /// look for e.g. \$() and replace with $() so we can substitute later with macEnvExpand()
-static void subMacros(std::string& new_macros, const char* macros, const char* loopVar)
+static void subMacros(std::string& new_macros, const char* macros)
 {
     new_macros = macros;
     std::smatch bracketSearch, braceSearch;
@@ -116,8 +116,8 @@ epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, co
         step = 1;
     }
     std::string macros_s, dbFile_s;
-    subMacros(macros_s, macros, loopVar);
-    subMacros(dbFile_s, dbFile, loopVar);
+    subMacros(macros_s, macros);
+    subMacros(dbFile_s, dbFile);
     MAC_HANDLE* mh = NULL;
 	char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);
@@ -171,8 +171,8 @@ epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, co
 		sep = default_sep;
 	}
     std::string macros_s, dbFile_s;
-    subMacros(macros_s, macros, loopVar);
-    subMacros(dbFile_s, dbFile, loopVar);
+    subMacros(macros_s, macros);
+    subMacros(dbFile_s, dbFile);
     MAC_HANDLE* mh = NULL;
 	char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);

--- a/utilitiesApp/src/dbLoadRecordsFuncs.h
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.h
@@ -1,0 +1,6 @@
+#ifndef db_load_records_func
+#define db_load_records_func
+
+void subMacros(std::string& new_macros, const char* macros);
+
+#endif

--- a/utilitiesApp/tests/dbLoadRecordsFuncs_tests.cc
+++ b/utilitiesApp/tests/dbLoadRecordsFuncs_tests.cc
@@ -1,0 +1,115 @@
+#include <string>
+
+#include "gtest/gtest.h"
+#include "dbLoadRecordsFuncs.h"
+#pragma warning( disable : 4129 )
+namespace {
+
+    TEST(SubMacrosTest, test_GIVEN_macro_using_brackets_THEN_removes_backslash) {
+        const char* macros = "string that contains \$(a macro)";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains $(a macro)");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_macro_using_brace_THEN_removes_backslash) {
+        const char* macros = "string that contains \${}";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains ${}");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_nested_macros_using_brackets_THEN_removes_backslash) {
+        const char* macros = "string that contains \$(\$())";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains $($())");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_nested_macro_using_brace_THEN_removes_backslash) {
+        const char* macros = "string that contains \${2 \${macros}}";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains ${2 ${macros}}");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_many_nested_macros_THEN_removes_backslash) {
+        const char* macros = "string that contains \${1\${2\${3\${4\${5\${6\${7\${8}}}}}}}}";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains ${1${2${3${4${5${6${7${8}}}}}}}}");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_nested_macro_using_both_THEN_removes_backslash) {
+        const char* macros = "string that contains \$(2 \${macros})";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains $(2 ${macros})");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_multiple_unnested_macro_using_both_THEN_removes_backslash) {
+        const char* macros = "string that contains \${1} \$(2)";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains ${1} $(2)");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_multiple_different_nested_macro_using_both_THEN_removes_backslash) {
+        const char* macros = "string that contains \${1\$(2\$(3))} \$(4\${5\${6}})";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains ${1$(2$(3))} $(4${5${6}})");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_no_macros_THEN_string_does_not_change) {
+        const char* macros = "string that contains no macro";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains no macro");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_macro_not_escaped_THEN_string_does_not_change) {
+        const char* macros = "string that contains non-escaped $(macro)";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string that contains non-escaped $(macro)");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_no_macros_AND_has_escapes_THEN_string_does_not_change) {
+        const char* macros = "string \that \contains no macro";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string \that \contains no macro");
+    }
+
+    TEST(SubMacrosTest, test_GIVEN_macro_not_escaped_AND_has_escapes_THEN_string_does_not_change) {
+        const char* macros = "string \that \()contains non-escaped $(macro)";
+        std::string new_macros;
+        subMacros(new_macros, macros);
+        
+        // Then:
+        ASSERT_EQ(new_macros, "string \that \()contains non-escaped $(macro)");
+    }
+}


### PR DESCRIPTION
dbloadrecordsloop changed to be able to handle macros of the form `\$(macro2\$(I))`. Also changed to more readable method of handling these macros.
https://github.com/ISISComputingGroup/IBEX/issues/7457
To test:
Change a call to dbloadrecordsloop  so that it uses a nested macro, e.g.
`EPICS\ioc\master\HUBER\iocBoot\iocHUBER-IOC-01\st-motor.cmd` line 36 change the call so that `AXIS=$(IOCNAME):\$(AXIS\$(I)=AXIS\$(I))`
Check that the IOC starts (if you use the HUBER_01 example you may need to start the emulator to check that it has started properly.
