### PR TITLE
Move test build to fix runner.exe failure

### DIFF
--- a/utilitiesApp/Makefile
+++ b/utilitiesApp/Makefile
@@ -4,4 +4,7 @@ DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Src*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *tests*))
+
+tests_DEPEND_DIRS += src
 include $(TOP)/configure/RULES_DIRS

--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -49,26 +49,14 @@ jcaput_LIBS += $(EPICS_BASE_IOC_LIBS)
 setprocessaffinity_SRCS += setprocessaffinity.cpp
 setprocessaffinity_SYS_LIBS_WIN32 += imagehlp
 
-# Copy DLLs that executables depend on, this avoids having to put additional things into PATH in config_env 
+# Copy DLLs that executables depend on, this avoids having to put additional things into PATH in config_env
+# these are also needed for running google tests in tests directory
 BIN_INSTALLS_WIN32 += $(wildcard $(ZLIB)/bin/$(EPICS_HOST_ARCH)/*.dll)
 BIN_INSTALLS_WIN32 += $(wildcard $(LIBJSON)/bin/$(EPICS_HOST_ARCH)/*.dll)
 BIN_INSTALLS_WIN32 += $(wildcard $(PCRE)/bin/$(EPICS_HOST_ARCH)/*.dll)
-
-# googleTest Runner
-ifeq ($(findstring 10.0,$(VCVERSION)),)
-SRC_DIRS += $(TOP)/utilitiesApp/tests
-
-GTESTPROD_HOST += runner
-runner_SRCS += calibration_range_tests.cc find_calibration_range_tests.cc dbLoadRecordsFuncs_tests.cc
-runner_SRCS += find_calibration_range_utils.cpp find_calibration_range_impl.cpp dbLoadRecordsFuncs.cpp
-runner_LIBS += zlib pcrecpp pcre libjson
-runner_LIBS += $(EPICS_BASE_IOC_LIBS)
-GTESTS += runner 
-endif
 
 #===========================
 
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
--include $(GTEST)/cfg/compat.RULES_BUILD

--- a/utilitiesApp/tests/Makefile
+++ b/utilitiesApp/tests/Makefile
@@ -1,0 +1,30 @@
+TOP=../..
+
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+#=============================
+
+#==================================================
+# build a support library
+
+USR_INCLUDES += -I"$(TOP)/../../../libraries/master/boost/include"
+
+# googleTest Runner
+ifeq ($(findstring 10.0,$(VCVERSION)),)
+SRC_DIRS += $(TOP)/utilitiesApp/src
+
+GTESTPROD_HOST += runner
+runner_SRCS += calibration_range_tests.cc find_calibration_range_tests.cc dbLoadRecordsFuncs_tests.cc
+runner_SRCS += find_calibration_range_utils.cpp find_calibration_range_impl.cpp dbLoadRecordsFuncs.cpp
+runner_LIBS += zlib pcrecpp pcre libjson
+runner_LIBS += $(EPICS_BASE_IOC_LIBS)
+GTESTS += runner
+endif
+
+#===========================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+-include $(GTEST)/cfg/compat.RULES_BUILD


### PR DESCRIPTION
Fix running of tests - runner.exe was build but failed to run as the dlls required had not been installed to bin at that point. Typing make a second time would work, but it would always fail on a clean build.

prior to PR   `make clean uninstall && make` would fail, this should work after change 

PR basically moves running of `runner.exe` to a different directory so the install to `bin` from `src` can complete 