### PR TITLE
Force to string to resolve ambiguity

### DIFF
--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -77,10 +77,10 @@ void subMacros(std::string& new_macros, const char* macros)
     // Check that we have done a search, and that the result of both is empty before finishing.
     while((!bracketSearch.empty())||(!braceSearch.empty())||(!bracketSearch.ready())){
         std::regex_search(new_macros, bracketSearch, bracketPattern);
-        new_macros = std::regex_replace(new_macros, bracketPattern, "$($1)");
+        new_macros = std::regex_replace(new_macros, bracketPattern, std::string("$($1)"));
         // Have to look twice to guarantee that brackets/curly braces are properly matched.
         std::regex_search(new_macros, braceSearch, bracePattern);
-        new_macros = std::regex_replace(new_macros, bracePattern, "${$1}");
+        new_macros = std::regex_replace(new_macros, bracePattern, std::string("${$1}"));
     }
 }
 


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/regex/regex_replace it looks like you should be able to have arg1 as a `string` and arg3 as a `const char*`, but gcc/rhel7 thinks this is ambiguous. So explicitly converting to string (note: avoided using string literals as not sure gcc 4.8 supports c++14)